### PR TITLE
add functionality to extend existing filters

### DIFF
--- a/QuackLibs.FilterBuilder.Tests/AndOrFilterBuilderTests.cs
+++ b/QuackLibs.FilterBuilder.Tests/AndOrFilterBuilderTests.cs
@@ -2,18 +2,18 @@ using FluentAssertions;
 
 namespace QuackLibs.FilterBuilder.Tests
 {
-    public class FilterBuilderTests
+    public class AndOrFilterBuilderTests
     {
         [Fact]
         public void WhenAFilterBuilderIsCreated_WithAnAndFilterThatEvaluatesToFalse_NoResultsAreReturned()
         {
             //arrange
-            var testPeople = new List<PeopleStud> { new PeopleStud { Name = "testj" } };
-            var filter = FilterBuilder.For<PeopleStud>(e => true)
-                                       .And(e => e.Name.Contains("test"))
-                                       .And(e => e.Name.Contains("je"));
+            var testPeople = new List<PersonStud> { new PersonStud { Name = "testj" } };
+            var filter = FilterBuilder.For<PersonStud>(true)
+                                      .And(e => e.Name.Contains("test"))
+                                      .And(e => e.Name.Contains("je"));
 
-            Func<PeopleStud, bool> compiledFilter = filter.Compile();
+            Func<PersonStud, bool> compiledFilter = filter;
 
             var result = testPeople.Where(compiledFilter);
 
@@ -26,12 +26,12 @@ namespace QuackLibs.FilterBuilder.Tests
         public void WhenAFilterBuilderIsCreated_WithAnAndFilterThatEvaluatesToTrue_OneResultsIsReturned()
         {
             //arrange
-            var testPeople = new List<PeopleStud> { new PeopleStud { Name = "testje" } };
-            var filter = FilterBuilder.For<PeopleStud>(e => true)
+            var testPeople = new List<PersonStud> { new PersonStud { Name = "testje" } };
+            var filter = FilterBuilder.For<PersonStud>(true)
                                       .And(e => e.Name.Contains("test"))
                                       .And(e => e.Name.Contains("je"));
 
-            var result = testPeople.Where(filter.Compile());
+            var result = testPeople.Where(filter);
 
             result.Should().NotBeEmpty();
             result.Count().Should().Be(1);
@@ -41,12 +41,12 @@ namespace QuackLibs.FilterBuilder.Tests
         public void WhenAFilterBuilderIsCreated_WithAnAndAndOrFilterThatEvaluatesToTrue_OneResultIsReturned()
         {
             //arrange
-            var testPeople = new List<PeopleStud> { new PeopleStud { Name = "testj" } };
-            var filter = FilterBuilder.For<PeopleStud>(e => true)
+            var testPeople = new List<PersonStud> { new PersonStud { Name = "testj" } };
+            var filter = FilterBuilder.For<PersonStud>(true)
                                       .And(e => e.Name.Contains("test"))
                                       .Or(e => e.Name.Contains("moot"));
 
-            var result = testPeople.Where(filter.Compile());
+            var result = testPeople.Where(filter);
 
             result.Should().NotBeEmpty();
             result.Count().Should().Be(1);

--- a/QuackLibs.FilterBuilder.Tests/ExtendFilterBuilderTests.cs
+++ b/QuackLibs.FilterBuilder.Tests/ExtendFilterBuilderTests.cs
@@ -1,0 +1,26 @@
+﻿using FluentAssertions;
+
+namespace QuackLibs.FilterBuilder.Tests
+{
+    public class ExtendFilterBuilderTests
+    {
+        [Fact]
+        public void WhenAFilterBuilderIsCreated_WithAnAndFilterThatEvaluatesToTrue_OneResultsIsReturned()
+        {
+            //arrange
+            var testPeople = new List<PersonStud> { new PersonStud { Name = "testje" } };
+            var filter1 = FilterBuilder.For<PersonStud>(true)
+                                       .And(e => e.Name.Contains("Foo"));
+
+            var extendedFilter = FilterBuilder.Extend<PersonStud>(filter1)
+                                              .Or(e => e.Name.Contains("test"));                                       
+                                 
+
+
+            var result = testPeople.Where(extendedFilter);
+
+            result.Should().NotBeEmpty();
+            result.Count().Should().Be(1);
+        }
+    }
+}

--- a/QuackLibs.FilterBuilder.Tests/OptionalFilterTests.cs
+++ b/QuackLibs.FilterBuilder.Tests/OptionalFilterTests.cs
@@ -7,12 +7,13 @@ public class OptionalFilterTests
     public void WhenAFilterBuilderIsCreated_WithAnOptionalilterThatEvaluatesToTrue_OneResultsIsReturned()
     {
         //arrange
-        var testPeople = new List<PeopleStud> { new PeopleStud { Name = "testje" } };
-        var filter = FilterBuilder.For<PeopleStud>(e => true)
+        var optionalFilterValue = new List<PersonStud> { new PersonStud { Name = "testje" } };
+
+        var filter = FilterBuilder.For<PersonStud>(true)
                                   .When(() => true)
                                     .Then(e => e.Name.Contains("testje"));
 
-        var result = testPeople.Where(filter.Compile());
+        var result = optionalFilterValue.Where(filter);
 
         result.Should().NotBeEmpty();
         result.Count().Should().Be(1);
@@ -22,14 +23,41 @@ public class OptionalFilterTests
     public void WhenAFilterBuilderIsCreated_WithAnOptionalFilterThatEvaluatesToFalse_NoResultsAreFound()
     {
         //arrange
-        var testPeople = new List<PeopleStud> { new PeopleStud { Name = "testje" } };
-        var filter = FilterBuilder.For<PeopleStud>(e => false)
+        var optionalFilterValue = new PersonStud { Name = "optional" };
+        var andFiltervalue = new PersonStud { Name = "andFilter" };
+
+        //act
+        var filter = FilterBuilder.For<PersonStud>(false)
                                   .When(() => false)
-                                    .Then(e => e.Name.Contains("testje"));
+                                    .Then(e => e.Name.Contains("optional"))
+                                  .And(e => e.FirstName == "andFilter");
 
-        var result = testPeople.Where(filter.Compile());
 
+        var result = new List<PersonStud> { optionalFilterValue, andFiltervalue }.Where(filter);
+
+        //assert
         result.Should().BeEmpty();
         result.Count().Should().Be(0);
     }
+
+
+    [Fact]
+    public void WhenAFilterBuilderIsCreated_WithAnOptionalFilterThatEvaluatesToFalse_TheAndFiltersIsExecuted()
+    {
+        //arrange
+        var optionalFilterValue = new PersonStud { Name = "optional" };
+        var andFiltervalue = new PersonStud { Name = "andFilter" };
+
+        Filter<PersonStud> filter = FilterBuilder.For<PersonStud>(defaultFilter: false)
+                                                 .When(() => false)
+                                                   .Then(e => e.Name.Contains("optional"))
+                                                 .And(e => e.Name.Equals("andFilter"));
+
+        var result = new List<PersonStud> { optionalFilterValue, andFiltervalue }.Where(filter);
+
+        result.Should().NotBeEmpty();
+        result.Count().Should().Be(1);
+    }
 }
+
+

--- a/QuackLibs.FilterBuilder.Tests/PeopleStud.cs
+++ b/QuackLibs.FilterBuilder.Tests/PeopleStud.cs
@@ -1,9 +1,11 @@
 ﻿namespace QuackLibs.FilterBuilder.Tests;
 
-public class PeopleStud
+public class PersonStud
 {
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public string FirstName { get; set; } = string.Empty;
     public string LastName { get; set; } = string.Empty;
+
+    public bool IsActive { get; set; }
 }

--- a/QuackLibs.FilterBuilder/Filter.cs
+++ b/QuackLibs.FilterBuilder/Filter.cs
@@ -7,42 +7,63 @@ public class Filter<T>
     /// <summary>
     /// The predicate that holds the current expression.
     /// </summary>
-    public Expression<Func<T, bool>> _currentFilter;
+    public Expression<Func<T, bool>>? _currentFilter;
+
+    /// <summary>
+    /// The default expression created on object construction. can be invoked when no additional filters are chained
+    /// </summary>
+    private readonly Expression<Func<T, bool>> _defaultFilter;
 
     /// <summary>
     /// Check if to see if the consumer has started the filter
     /// </summary>
-    public bool HasFilter => _currentFilter != null;
+    private bool HasFilter => (_currentFilter != null) && (_currentFilter != _defaultFilter);
 
-    internal Filter(Expression<Func<T, bool>> expression)
+    internal Filter(bool defaultFilter)
     {
-        _currentFilter = expression;
+        _defaultFilter = e => defaultFilter;
     }
 
-    public Expression<Func<T, bool>> InitializeFilter(Expression<Func<T, bool>> filter)
+    internal Filter(Expression<Func<T, bool>> defaultFilter) : this(false) 
+    {
+        _currentFilter = defaultFilter;
+    }
+
+    private Expression<Func<T, bool>> InitializeFilter(Expression<Func<T, bool>> filter)
     {
         if (HasFilter)
-            throw new Exception("Filter can only be started once");
+            throw new Exception("Filter cannot be started more than once");
 
-        return this._currentFilter = filter;
+        return _currentFilter = filter;
     }
 
     /// <summary>Or</summary>
-    public Expression<Func<T, bool>> Or(Expression<Func<T, bool>> expr2)
+    public Filter<T> Or(Expression<Func<T, bool>> expr2)
     {
-        return (HasFilter) ? _currentFilter = _currentFilter.Or(expr2) : InitializeFilter(expr2);
+        if (HasFilter)
+            _currentFilter = _currentFilter.Or(expr2);
+        else
+            InitializeFilter(expr2);
+
+        return this;
     }
 
     /// <summary>And</summary>
-    public Expression<Func<T, bool>> And(Expression<Func<T, bool>> expr2)
+    public Filter<T> And(Expression<Func<T, bool>> expr2)
     {
-        return (HasFilter) ? _currentFilter = _currentFilter.And(expr2) : InitializeFilter(expr2);
+        if (HasFilter)
+            _currentFilter = _currentFilter.And(expr2);
+        else
+            InitializeFilter(expr2);
+
+        return this;
     }
 
     public OptionalFilter<T> When(Func<bool> condition)
     {
         return new OptionalFilter<T>(this, condition);
     }
+
     /// <summary>
     /// Allows this object to be implicitely converted to <see cref="Func{T, TResult}"/>
     /// </summary>
@@ -50,7 +71,7 @@ public class Filter<T>
     public static implicit operator Func<T, bool>(Filter<T> filter) => filter._currentFilter.Compile();
 
     /// <summary>
-    /// Allows this object to be implicitely converted to an Expression{Func{T, bool}}.
+    /// Allows this object to be implicitely converted to an <see cref="{Expression{Func{T, bool}}"/>.
     /// </summary>
     /// <param name="filter"></param>
     public static implicit operator Expression<Func<T, bool>>(Filter<T> filter) => filter._currentFilter;

--- a/QuackLibs.FilterBuilder/FilterBuilder.cs
+++ b/QuackLibs.FilterBuilder/FilterBuilder.cs
@@ -7,6 +7,22 @@ public class FilterBuilder
 {
     private FilterBuilder() { }
 
-    public static Filter<T> For<T>(Expression<Func<T, bool>> expression) => new(expression);    
+    /// <summary>
+    /// Start a new filter for <see cref="T"/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="defaultFilter"></param>
+    /// <returns></returns>
+    public static Filter<T> For<T>(bool defaultFilter) => new(defaultFilter);
+
+
+    /// <summary>
+    /// Extend an existing <see cref="Filter{T}"/> or <see cref="{Expression{Func{T, bool}}""/>
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="defaultFilter"></param>
+    /// <returns></returns>
+    public static Filter<T> Extend<T>(Expression<Func<T, bool>> existingFilter) => new(existingFilter);
+
 }
 

--- a/QuackLibs.FilterBuilder/FilterOperators.cs
+++ b/QuackLibs.FilterBuilder/FilterOperators.cs
@@ -4,21 +4,15 @@ namespace QuackLibs.FilterBuilder;
 
 public static class FilterOperators
 {
-    public static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> currentFilter, Expression<Func<T, bool>> additionalFilter)
+    internal static Expression<Func<T, bool>> Or<T>(this Expression<Func<T, bool>> currentFilter, Expression<Func<T, bool>> additionalFilter)
     {
         var expr2Body = new RebindParameterVisitor(additionalFilter.Parameters[0], currentFilter.Parameters[0]).Visit(additionalFilter.Body);
         return Expression.Lambda<Func<T, bool>>(Expression.OrElse(currentFilter.Body, expr2Body), currentFilter.Parameters);
     }
 
-    public static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> currentFilter, Expression<Func<T, bool>> additionalFilter)
+    internal static Expression<Func<T, bool>> And<T>(this Expression<Func<T, bool>> currentFilter, Expression<Func<T, bool>> additionalFilter)
     {
         var expr2Body = new RebindParameterVisitor(additionalFilter.Parameters[0], currentFilter.Parameters[0]).Visit(additionalFilter.Body);
         return Expression.Lambda<Func<T, bool>>(Expression.AndAlso(currentFilter.Body, expr2Body), currentFilter.Parameters);
-    }
-
-    public static Expression<Func<T, bool>> Coalesce<T>(this Expression<Func<T, bool>> currentFilter, Expression<Func<T, bool>> additionalFilter)
-    {
-        var expr2Body = new RebindParameterVisitor(additionalFilter.Parameters[0], currentFilter.Parameters[0]).Visit(additionalFilter.Body);
-        return Expression.Lambda<Func<T, bool>>(Expression.Coalesce(currentFilter.Body, expr2Body), currentFilter.Parameters);
     }
 }

--- a/QuackLibs.FilterBuilder/OptionalFilter.cs
+++ b/QuackLibs.FilterBuilder/OptionalFilter.cs
@@ -1,6 +1,7 @@
 ﻿using System.Linq.Expressions;
 
 namespace QuackLibs.FilterBuilder;
+
 public class OptionalFilter<T>
 {
     private readonly Func<bool> _condition;
@@ -12,7 +13,7 @@ public class OptionalFilter<T>
         _condition = condition;
     }
 
-    public Expression<Func<T, bool>> Then(Expression<Func<T, bool>> expr2)
+    public Filter<T> Then(Expression<Func<T, bool>> expr2)
     {
         if (_condition())
             _filter.And(expr2);

--- a/QuackLibs.FilterBuilder/assemblyInfo.cs
+++ b/QuackLibs.FilterBuilder/assemblyInfo.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+[assembly: InternalsVisibleToAttribute("QuackLibs.FilterBuilder.Tests")]
+namespace QuackLibs.FilterBuilder;
+
+
+public static class assemblyInfo
+{
+}


### PR DESCRIPTION
Extend existing filters, sanitize code, ensure that the filter<T> class returns instances of filter<T> instead of expressions to make the fluent builder work correctly